### PR TITLE
Rework bot to take be able to check based on both templates and a list of pages at the same time

### DIFF
--- a/ithenticate.py
+++ b/ithenticate.py
@@ -1,0 +1,45 @@
+import xmlrpclib
+import sys
+sys.path.append('../plagiabot')
+from plagiabot_config import ithenticate_user, ithenticate_password
+from flup.server.fcgi import WSGIServer
+from cgi import parse_qs, escape
+
+#cgitb.enable()
+def get_view_url(report_id):
+    report='a'
+    a=''
+    try:
+        a='a'
+        server_i = xmlrpclib.ServerProxy("https://api.ithenticate.com/rpc")
+        a='b'
+        login_response = server_i.login({"username": ithenticate_user, "password": ithenticate_password})
+        a='log'
+        assert (login_response['status'] == 200)
+        a='loged'
+        sid = login_response['sid']
+        a='log1'
+        report = server_i.report.get({'id': report_id, 'sid': sid})
+        a='log2'
+        return report['view_only_url']
+        #return report
+    except xmlrpclib.ProtocolError as e:
+       return ';-('#+'!'+e.__class__.__name__+e.errmsg+'!'+str(e.errcode)+'%s'%e.headers
+    except Exception as e:
+       return ';('
+
+
+def app(environ, start_response):
+    start_response('200 OK', [('Content-Type', 'text/html')])
+    q=parse_qs(environ['QUERY_STRING'])
+    yield '<h1>Redirecting to similarity report...</h1>'
+    if 'rid' in q and len(q['rid']) > 0:
+        url=get_view_url(q['rid'][0])
+        if 'http' in url:
+            #yield '<br>To get to report please follow <a href="%s">%s</a>.'%(url, url)
+            yield '<script>window.location.href="%s";</script>'%url
+        else:
+            yield url
+
+WSGIServer(app).run()
+

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -252,15 +252,15 @@ class PlagiaBot:
         editor = page._revisions[new_rev].user
         local_messages = messages[self.site.lang] if self.site.lang in messages else messages['en']
         try:
-			reverted_edit = re.compile(local_messages['rollback_of_summary'].format(editor, new_rev))
-			for rev in page._revisions:
-				user = page._revisions[rev].user
-				comment = page._revisions[rev].comment
-				is_the_editor = editor in comment
-				is_revert = reverted_edit.match(comment)
-				if is_revert and is_the_editor:
-					print('Was rolledback by {}: {}'.format(user,comment))
-					rolledback = True
+            reverted_edit = re.compile(local_messages['rollback_of_summary'].format(editor, new_rev))
+            for rev in page._revisions:
+                user = page._revisions[rev].user
+                comment = page._revisions[rev].comment
+                is_the_editor = editor in comment
+                is_revert = reverted_edit.match(comment)
+                if is_revert and is_the_editor:
+                    print('Was rolledback by {}: {}'.format(user,comment))
+                    rolledback = True
         except:
             pass
         return rolledback
@@ -290,7 +290,7 @@ class PlagiaBot:
 
         # also invoke search to look in other articles?
         return content
- 
+
     def run(self):
         global MIN_SIZE, DEBUG_MODE, WORDS_QUOTE
         local_messages = messages[self.site.lang] if self.site.lang in messages else messages['en']
@@ -434,46 +434,46 @@ def db_changes_generator(site, talk_template=None, page_of_pages=None, days=1, n
     
     # If page_of_pages parameter is given, get the query for the list of linked pages; otherwise, get an empty placeholder query.
     if page_of_pages:
-		list_of_pages = articles_from_list(site, page_of_pages, namespace)
+        list_of_pages = articles_from_list(site, page_of_pages, namespace)
         sql_page_selects.append(list_of_pages)
     
     # If talk_template parameter is given, get the query for the list of linked pages; otherwise, get an empty placeholder query.
     if talk_template:
-		templated_pages = articles_from_talk_template(site, talk_template, namespace)
-		sql_page_selects.append(templated_pages)
+        templated_pages = articles_from_talk_template(site, talk_template, namespace)
+        sql_page_selects.append(templated_pages)
 
-	if len(sql_page_selects)==0:
-		sql_join = ""
-	else:
-		# If there are multiple selects for sets of page titles, we want to get the union of these selects.
-		union_of_lists = " UNION ".join(x for x in sql_page_selects)
-		pages = """
-		inner join
-			( '%s' )
-			pages
-		on
-			rc_title=page_title
-			""" % union_of_lists
+    if len(sql_page_selects)==0:
+        sql_join = ""
+    else:
+        # If there are multiple selects for sets of page titles, we want to get the union of these selects.
+        union_of_lists = " UNION ".join(x for x in sql_page_selects)
+        pages = """
+        inner join
+            ( '%s' )
+            pages
+        on
+            rc_title=page_title
+            """ % union_of_lists
 
-	# Use the select for a set of pages to find changes to compose a query for changes to those pages
-	query = '''
-		select rc_this_oldid, rc_last_oldid, rc_title, rc_new_len-rc_old_len as diffSize
-		from
-			recentchanges
-		%s
-			left join
-				user_groups
-			on
-				rc_user=ug_user and
-				rc_type < 5 and
-				ug_group = 'bot'
-			where ug_group is NULL and
-				rc_namespace=0 and
-				rc_timestamp > %s and
-				rc_new_len-rc_old_len>500/* and
-				rc_comment not like '%%rollback%%'*/
-			order by  rc_new_len-rc_old_len desc
-		''' % (pages, date_limit))
+    # Use the select for a set of pages to find changes to compose a query for changes to those pages
+    query = '''
+        select rc_this_oldid, rc_last_oldid, rc_title, rc_new_len-rc_old_len as diffSize
+        from
+            recentchanges
+        %s
+            left join
+                user_groups
+            on
+                rc_user=ug_user and
+                rc_type < 5 and
+                ug_group = 'bot'
+            where ug_group is NULL and
+                rc_namespace=0 and
+                rc_timestamp > %s and
+                rc_new_len-rc_old_len>500/* and
+                rc_comment not like '%%rollback%%'*/
+            order by  rc_new_len-rc_old_len desc
+        ''' % (pages, date_limit))
 
     ignore_summary = messages[site.lang]['ignore_summary'] if site.lang in messages else ''
     print(query)
@@ -517,7 +517,7 @@ def main(*args):
     for arg in pywikibot.handleArgs(*args):
         site = pywikibot.Site()
         if arg.startswith('-talkTemplate:'):
-			talk_template=arg[len("-talkTemplate:"):]
+            talk_template=arg[len("-talkTemplate:"):]
         elif arg.startswith('-pagesLinkedFrom:'):
             page_of_pages=arg[len("-pagesLinkedFrom:"):]
         elif arg.startswith('-recentchanges:'):
@@ -540,8 +540,8 @@ def main(*args):
             gen = pagegenerators.PreloadingGenerator(gen)
             generator = [(p, p.latestRevision(), 0) for p in gen]
 
-	if (talk_template or page_of_pages or days):
-		generator =  db_changes_generator(site, talk_template, page_of_pages, days, namespace)
+    if (talk_template or page_of_pages or days):
+        generator =  db_changes_generator(site, talk_template, page_of_pages, days, namespace)
 
     if generator is None:
         pywikibot.showHelp()

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -473,7 +473,7 @@ def db_changes_generator(site, talk_template=None, page_of_pages=None, days=1, n
                 rc_new_len-rc_old_len>500/* and
                 rc_comment not like '%%rollback%%'*/
             order by  rc_new_len-rc_old_len desc
-        ''' % (pages, date_limit))
+        ''' % (pages, date_limit)
 
     ignore_summary = messages[site.lang]['ignore_summary'] if site.lang in messages else ''
     print(query)

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -410,7 +410,7 @@ def articles_from_talk_template(site, talk_template, namespace=1):
 
 
     list_sql = """
-    select pl_title as page_title
+    select page_title
     from
         templatelinks
     inner join
@@ -420,7 +420,7 @@ def articles_from_talk_template(site, talk_template, namespace=1):
                 page_namespace=1
         where 
                 tl_title='%s' and
-                tl_namespace=10 and tl_from_namespace=%s
+                tl_namespace=10 and tl_from_namespace=%st
                 """ % (talk_template, namespace)
 
     return list_sql

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -54,7 +54,7 @@ MIN_SIZE = 500  # minimum length of added text for sending to server
 MIN_PERCENTAGE = 50
 WORDS_QUOTE = 50
 MAX_AGE = 1 # how many days worth of recent changes to check
-DIFF_URL = '//tools.wmflabs.org/eranbot/ithenticate.py?rid=%s'
+DIFF_URL = '//tools.wmflabs.org/plaigsossbot/ithenticate.py?rid=%s'
 messages = {
     'en': {
         'table-title': 'Title',

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -512,6 +512,9 @@ def main(*args):
     global ignore_sites, DEBUG_MODE
     report_page = None
     generator = None
+    talk_template = None
+    page_of_pages = None
+    days = None
     genFactory = pagegenerators.GeneratorFactory()
 
     for arg in pywikibot.handleArgs(*args):

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -400,7 +400,7 @@ class PlagiaBot:
         else:
             pywikibot.output('No violation found!')
 
-def articles_from_talk_template(site, talk_template, namespace=1):
+def articles_from_talk_template(site, talk_template):
     """
     Given a page in the Project: (Wikipedia:) namespace, compose the sql query for finding all articles linked from the page. The output can then be joined with additional sql queries to select recent changes to those articles.
     """
@@ -420,7 +420,7 @@ def articles_from_talk_template(site, talk_template, namespace=1):
                 page_namespace=1
         where 
                 tl_title='%s' and
-                tl_namespace=10 and tl_from_namespace=%s
+                tl_namespace=10 and tl_from_namespace=1
                 """ % (talk_template, namespace)
 
     return list_sql
@@ -467,7 +467,7 @@ def db_changes_generator(site, talk_template=None, page_of_pages=None, days=1, n
     
     # If talk_template parameter is given, get the query for the list of linked pages; otherwise, get an empty placeholder query.
     if talk_template:
-        templated_pages = articles_from_talk_template(site, talk_template, namespace)
+        templated_pages = articles_from_talk_template(site, talk_template)
         sql_page_selects.append(templated_pages)
 
     if len(sql_page_selects)==0:

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -390,7 +390,7 @@ class PlagiaBot:
         else:
             pywikibot.output('No violation found!')
 
-def db_changes_from_list_generator(site, page_of_pages, days=0.5):
+def db_changes_from_list_generator(site, page_of_pages, days=8):
     """
     Generator for changes to pages linked from a specific page
     """
@@ -430,7 +430,7 @@ from
         rc_type < 5 and
         ug_group = 'bot'
     where ug_group is NULL and
-        rc_namespace=0 and
+        rc_namespace in (0,2) and
         rc_timestamp > %s and
         rc_new_len-rc_old_len>500 and
         rc_comment not rlike '%s'

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -18,13 +18,13 @@ Command line options:
 Usage examples:
 
 Report on possible violations in Wikiproject Medicine related articles:
-    python plagtarismbot.py -lang:en -report:"Wikipedia:MED/Copyright" -talkTemplate:"WikiProject_Medicine"
+    python plagiabot.py -lang:en -report:"Wikipedia:MED/Copyright" -talkTemplate:"WikiProject_Medicine"
 
 Report on possible violations in the last 3 days to console:
-    python plagtarismbot.py -recentchanges:3
+    python plagiabot.py -recentchanges:3
 
 Report on possible violations in the top 100 recent changes (no DB access required):
-    python plagtarismbot.py -api_recentchanges:100
+    python plagiabot.py -api_recentchanges:100
 """
 import time
 import datetime

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -49,6 +49,7 @@ docuReplacements = {
 MIN_SIZE = 500  # minimum length of added text for sending to server
 MIN_PERCENTAGE = 50
 WORDS_QUOTE = 50
+MAX_AGE = 1 # how many days worth of recent changes to check
 DIFF_URL = '//tools.wmflabs.org/eranbot/ithenticate.py?rid=%s'
 messages = {
     'en': {
@@ -544,6 +545,8 @@ def main(*args):
             generator = [(p, p.latestRevision(), 0) for p in gen]
 
     if (talk_template or page_of_pages or days):
+        if not days:
+            days = MAX_AGE
         generator =  db_changes_generator(site, talk_template, page_of_pages, days, namespace)
 
     if generator is None:

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -421,11 +421,9 @@ def articles_from_talk_template(site, talk_template):
         where 
                 tl_title='%s' and
                 tl_namespace=10 and tl_from_namespace=1
-                """ % (talk_template, namespace)
+                """ % (talk_template)
 
     return list_sql
-
-
 
 def articles_from_list(site, page_of_pages, namespace=0):
     """
@@ -582,7 +580,6 @@ def main(*args):
     else:
         bot = PlagiaBot(pywikibot.Site(), generator, report_page)
         bot.run()
-
 
 if __name__ == "__main__":
     try:

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -253,14 +253,14 @@ class PlagiaBot:
         local_messages = messages[self.site.lang] if self.site.lang in messages else messages['en']
         try:
 			reverted_edit = re.compile(local_messages['rollback_of_summary'].format(editor, new_rev))
-        for rev in page._revisions:
-			user = page._revisions[rev].user
-        comment = page._revisions[rev].comment
-        is_the_editor = editor in comment
-        is_revert = reverted_edit.match(comment)
-        if is_revert and is_the_editor:
-            print('Was rolledback by {}: {}'.format(user,comment))
-            rolledback = True
+			for rev in page._revisions:
+				user = page._revisions[rev].user
+				comment = page._revisions[rev].comment
+				is_the_editor = editor in comment
+				is_revert = reverted_edit.match(comment)
+				if is_revert and is_the_editor:
+					print('Was rolledback by {}: {}'.format(user,comment))
+					rolledback = True
         except:
             pass
         return rolledback

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -8,18 +8,22 @@ to find copyright violations.
 Output can be to console (default) or to wiki page 
 
 Command line options:
-    -report:Page        page name to write report to.
-    -talkTemplate:Foo   Run on diffs of a pages with talk page containing {{Foo}}
-    -recentchanges:X    Number of days to fetch recent changes. For 12 hours set 0.5.
-    -blacklist:Page     page containing a blacklist of sites to ignore (Wikipedia mirrors)
-                            [[User:EranBot/Copyright/Blacklist]] is collaboratively maintained
-                            blacklist for English Wikipedia.
+    -report:Page            page name to write report to.
+    -talkTemplate:Foo       Run on diffs of a pages with talk page containing {{Foo}}
+    -pagesLinkedFrom:Bar    Run on diffs of pages linked from the page [[Wikipedia:Bar]]
+    -recentchanges:X        Number of days to fetch recent changes. For 12 hours set 0.5.
+    -blacklist:Page         page containing a blacklist of sites to ignore (Wikipedia mirrors)
+                                [[User:EranBot/Copyright/Blacklist]] is collaboratively maintained
+                                blacklist for English Wikipedia.
 
 &params;
 
 Usage examples:
 
-Report on possible violations in Wikiproject Medicine related articles:
+Report on WikiProject Medicine articles AND pages linked from the [[Wikipedia:Education noticeboard/Incidents]]
+    python plagiabot.py -lang:en -report:"Wikipedia:MED/Copyright" -talkTemplate:"WikiProject_Medicine" -pagesLinkedFrom:"Education_noticeboard/Incidents" -blacklist:"User:EranBot/Copyright/Blacklist"
+
+Report on possible violations only on Wikiproject Medicine related articles:
     python plagiabot.py -lang:en -report:"Wikipedia:MED/Copyright" -talkTemplate:"WikiProject_Medicine"
 
 Report on possible violations in the last 3 days to console:

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -420,7 +420,7 @@ def articles_from_talk_template(site, talk_template, namespace=1):
                 page_namespace=1
         where 
                 tl_title='%s' and
-                tl_namespace=10 and tl_from_namespace=%st
+                tl_namespace=10 and tl_from_namespace=%s
                 """ % (talk_template, namespace)
 
     return list_sql

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -9,8 +9,11 @@ Output can be to console (default) or to wiki page
 
 Command line options:
     -report:Page 		page name to write report to.
-    -talkTempalte:XX	Run on diffs of a pages with talk page containing {{talkTemplate}}
+    -talkTemplate:Foo	Run on diffs of a pages with talk page containing {{Foo}}
     -recentchanges:X	Number of days to fetch recent changes. For 12 hours set 0.5.
+    -blacklist:Page     page containing a blacklist of sites to ignore (Wikipedia mirrors)
+                            [[User:EranBot/Copyright/Blacklist]] is collaboratively maintained
+                            blacklist for English Wikipedia.
 
 Usage examples:
 

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -364,14 +364,12 @@ class PlagiaBot:
         reports_source = [{'source': self.poll_response(upload_id, rev_details['title'], added_lines),
                            'diffTemplate': local_messages['template-diff']} for rev_details, upload_id, added_lines in uploads]
 
+        # Define the format of an individual report row.
         report_template = u"""
-|- valign="top"
-| [[{title}]]
-| {diff_date} ({{{{{diffTemplate}|{title}|{new}|{old}}}}}, [{{{{fullurl:{title}|action=history}}}} {{{{subst:MediaWiki:Hist}}}}])
-| [[User:{user}|]] ([[User talk:{user}|{{{{subst:MediaWiki:Talk}}}}]])
-| style="font-size:small" |
+{{{{plagiabot row | article = {title} | timestamp = {diff_date} | diff = {new} | oldid = {old} | user = {user} | details =
 {source}
-|"""
+| status =
+}}}}"""
         reports_details = [dict(details[0].items() + source.items()) for details, source in zip(uploads, reports_source)
                            if len(source['source']) > 0]
         reports_details = [report_template.format(**rep) for rep in reports_details]
@@ -593,3 +591,4 @@ if __name__ == "__main__":
 
         traceback.print_exc()
         pywikibot.stopme()
+

--- a/plagiabot.py
+++ b/plagiabot.py
@@ -248,13 +248,13 @@ class PlagiaBot:
             pywikibot.output("Added lines don't exist in current version - skipping")
             return True
 
-        # alternatily look for rollback of that revision
+        # alternatively, look for rollback of that revision
         editor = page._revisions[new_rev].user
         local_messages = messages[self.site.lang] if self.site.lang in messages else messages['en']
         try:
-        reverted_edit = re.compile(local_messages['rollback_of_summary'].format(editor, new_rev))
+			reverted_edit = re.compile(local_messages['rollback_of_summary'].format(editor, new_rev))
         for rev in page._revisions:
-        user = page._revisions[rev].user
+			user = page._revisions[rev].user
         comment = page._revisions[rev].comment
         is_the_editor = editor in comment
         is_revert = reverted_edit.match(comment)


### PR DESCRIPTION
I've refactored the way lists of changes are generated so that the bot could simultaneously check pages from WikiProject Medicine and a manually compiled list of additional pages. In the short term (before the bot goes global), this would make it possible to keep running the bot for WikiProject Medicine and also add on a list of articles being edited by student editors.
